### PR TITLE
feat: show service specific images on home cards

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -71,7 +71,7 @@
             <div class="services-grid">
                 <div *ngFor="let service of services; let i = index" class="service-card"
                     (click)="openBookingModal(service)">
-                    <div class="service-image" [style.background-image]="'url(' + getServiceImage(i) + ')'">
+                    <div class="service-image" [style.background-image]="'url(' + (service.imageUrl || defaultServiceImage) + ')'">
                         <div class="service-badge" *ngIf="i === 0">Most Popular</div>
                         <div class="service-overlay">
                             <div class="service-icon">

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -21,6 +21,7 @@ export class HomeComponent implements OnInit {
   showSuccessModal = false;
   isSubmitting = false;
   today = new Date().toISOString().split("T")[0];
+  defaultServiceImage = "assets/service-images/default-service.svg";
 
   bookingFormData: BookingFormData = {
     customerName: "",
@@ -50,16 +51,6 @@ export class HomeComponent implements OnInit {
       "airport-transfer": "✈️",
     };
     return icons[serviceId] || "🎯";
-  }
-
-  getServiceImage(index: number): string {
-    const images = [
-      "assets/service-1.jpeg",
-      "assets/service-2.jpeg",
-      "assets/service-3.jpeg",
-      "assets/service-4.jpeg",
-    ];
-    return images[index] || images[0];
   }
 
   openBookingModal(service: Service) {

--- a/src/app/services/services.service.ts
+++ b/src/app/services/services.service.ts
@@ -13,6 +13,7 @@ export class ServicesService {
         "Explore Mauritius at your own pace with our reliable and affordable car rental service. Perfect for families and groups who want freedom to travel.",
       price: 2500,
       duration: "Per day",
+      imageUrl: "assets/service-images/car-rental.svg",
       features: [
         "Comprehensive insurance",
         "24/7 roadside assistance",
@@ -28,6 +29,7 @@ export class ServicesService {
         "Discover Mauritius with our experienced local guide. Visit the most beautiful places including Chamarel, Black River Gorges, and more.",
       price: 3500,
       duration: "Full day (8 hours)",
+      imageUrl: "assets/service-images/sightseeing-tour.svg",
       features: [
         "Professional local guide",
         "Visit 4-5 attractions",
@@ -43,6 +45,7 @@ export class ServicesService {
         "Enjoy a relaxing day on the crystal-clear waters of Mauritius. Snorkeling, swimming, and a delicious BBQ lunch on board.",
       price: 4500,
       duration: "Full day (6 hours)",
+      imageUrl: "assets/service-images/catamaran-trip.svg",
       features: [
         "Comfortable catamaran",
         "Snorkeling equipment",
@@ -58,6 +61,7 @@ export class ServicesService {
         "Visit the famous Ile Aux Cerfs island with its pristine white sand beaches and crystal clear waters. Perfect for relaxation and water activities.",
       price: 4000,
       duration: "Full day (7 hours)",
+      imageUrl: "assets/service-images/ile-aux-cerfs.svg",
       features: [
         "Boat transfer included",
         "Beach access",
@@ -73,6 +77,7 @@ export class ServicesService {
         "Comfortable and reliable airport transfer service. We'll pick you up from the airport and take you to your hotel or anywhere in Mauritius.",
       price: 1500,
       duration: "One way",
+      imageUrl: "assets/service-images/airport-transfer.svg",
       features: [
         "Meet & greet service",
         "Air-conditioned vehicles",

--- a/src/assets/service-images/airport-transfer.svg
+++ b/src/assets/service-images/airport-transfer.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500">
+  <defs>
+    <linearGradient id="airportGradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2c3e50" />
+      <stop offset="100%" stop-color="#4ca1af" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="500" fill="url(#airportGradient)" rx="30" />
+  <g fill="#ffffff" opacity="0.25">
+    <rect x="80" y="80" width="200" height="40" rx="20" />
+    <rect x="520" y="120" width="180" height="35" rx="18" />
+    <circle cx="680" cy="360" r="70" />
+  </g>
+  <g transform="translate(140,170)" fill="#ffffff">
+    <path d="M160 0l60 180h160l20 40H40l40-80 80-20z" opacity="0.95" />
+    <rect x="180" y="180" width="200" height="40" rx="20" />
+  </g>
+  <text x="50%" y="82%" text-anchor="middle" font-family="'Poppins', 'Segoe UI', sans-serif" font-size="58" fill="#eaf6f6" font-weight="600">
+    Airport Transfers
+  </text>
+</svg>

--- a/src/assets/service-images/car-rental.svg
+++ b/src/assets/service-images/car-rental.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500">
+  <defs>
+    <linearGradient id="carGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0b63ce" />
+      <stop offset="100%" stop-color="#58a9ff" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="500" fill="url(#carGradient)" rx="30" />
+  <g fill="#fff" opacity="0.2">
+    <circle cx="140" cy="120" r="70" />
+    <circle cx="680" cy="380" r="90" />
+    <rect x="320" y="60" width="300" height="40" rx="20" />
+  </g>
+  <g stroke="#fff" stroke-width="16" fill="none" stroke-linecap="round" stroke-linejoin="round" transform="translate(140,200)">
+    <path d="M40 100h320l40 80H0z" />
+    <circle cx="80" cy="200" r="40" fill="#fff" />
+    <circle cx="320" cy="200" r="40" fill="#fff" />
+    <path d="M80 120l60-80h140l60 80" />
+  </g>
+  <text x="50%" y="82%" text-anchor="middle" font-family="'Poppins', 'Segoe UI', sans-serif" font-size="64" fill="#ffffff" font-weight="600">
+    Car Rental Service
+  </text>
+</svg>

--- a/src/assets/service-images/catamaran-trip.svg
+++ b/src/assets/service-images/catamaran-trip.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500">
+  <defs>
+    <linearGradient id="seaGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#00c6ff" />
+      <stop offset="100%" stop-color="#0072ff" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="500" fill="url(#seaGradient)" rx="30" />
+  <g fill="#ffffff" opacity="0.3">
+    <path d="M0 360c60 30 140 30 200 0s140-30 200 0 140 30 200 0 140-30 200 0v140H0z" />
+  </g>
+  <g fill="#ffffff" transform="translate(160,120)">
+    <path d="M160 200l120-200 60 200z" opacity="0.9" />
+    <path d="M0 240h400l-40 60H40z" opacity="0.95" />
+  </g>
+  <text x="50%" y="80%" text-anchor="middle" font-family="'Poppins', 'Segoe UI', sans-serif" font-size="60" fill="#003d7a" font-weight="600">
+    Catamaran Cruise
+  </text>
+</svg>

--- a/src/assets/service-images/default-service.svg
+++ b/src/assets/service-images/default-service.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500">
+  <defs>
+    <linearGradient id="defaultGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#7f7fd5" />
+      <stop offset="50%" stop-color="#86a8e7" />
+      <stop offset="100%" stop-color="#91eae4" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="500" fill="url(#defaultGradient)" rx="30" />
+  <g fill="#ffffff" opacity="0.25">
+    <circle cx="120" cy="110" r="70" />
+    <circle cx="620" cy="120" r="90" />
+    <rect x="200" y="360" width="400" height="40" rx="20" />
+  </g>
+  <g fill="none" stroke="#ffffff" stroke-width="16" stroke-linecap="round" stroke-linejoin="round" transform="translate(200,180)">
+    <rect x="0" y="0" width="360" height="200" rx="30" />
+    <path d="M80 260h200" />
+    <path d="M60 60h240" />
+    <path d="M60 120h160" />
+  </g>
+  <text x="50%" y="82%" text-anchor="middle" font-family="'Poppins', 'Segoe UI', sans-serif" font-size="56" fill="#ffffff" font-weight="600">
+    Shanal Tours
+  </text>
+</svg>

--- a/src/assets/service-images/ile-aux-cerfs.svg
+++ b/src/assets/service-images/ile-aux-cerfs.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500">
+  <defs>
+    <linearGradient id="islandGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4cd964" />
+      <stop offset="100%" stop-color="#00b894" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="500" fill="url(#islandGradient)" rx="30" />
+  <g opacity="0.35" fill="#ffffff">
+    <circle cx="140" cy="120" r="60" />
+    <circle cx="640" cy="160" r="90" />
+  </g>
+  <g transform="translate(120,200)">
+    <ellipse cx="260" cy="160" rx="220" ry="110" fill="#f7f1a0" />
+    <path d="M120 120c60-80 220-80 280 0 40 50 0 140-140 140s-180-90-140-140z" fill="#2ecc71" />
+    <g fill="#1e8449">
+      <rect x="200" y="60" width="20" height="80" rx="10" />
+      <rect x="320" y="80" width="20" height="80" rx="10" />
+      <path d="M210 40l40 60h-80z" />
+      <path d="M330 50l30 50h-60z" />
+    </g>
+  </g>
+  <text x="50%" y="82%" text-anchor="middle" font-family="'Poppins', 'Segoe UI', sans-serif" font-size="58" fill="#0a3d2b" font-weight="600">
+    Ile Aux Cerfs Escape
+  </text>
+</svg>

--- a/src/assets/service-images/sightseeing-tour.svg
+++ b/src/assets/service-images/sightseeing-tour.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 500">
+  <defs>
+    <linearGradient id="tourGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f9a826" />
+      <stop offset="100%" stop-color="#ffdd78" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="500" fill="url(#tourGradient)" rx="30" />
+  <g fill="#ffffff" opacity="0.35">
+    <circle cx="150" cy="130" r="80" />
+    <circle cx="640" cy="120" r="60" />
+    <circle cx="720" cy="160" r="30" />
+  </g>
+  <g fill="#ffffff" transform="translate(120,200)">
+    <path d="M120 160l120-160 120 160z" opacity="0.8" />
+    <path d="M0 200h560v40H0z" opacity="0.9" />
+    <circle cx="420" cy="60" r="40" />
+  </g>
+  <text x="50%" y="78%" text-anchor="middle" font-family="'Poppins', 'Segoe UI', sans-serif" font-size="60" fill="#8b4100" font-weight="600">
+    Guided Sightseeing Tour
+  </text>
+</svg>


### PR DESCRIPTION
## Summary
- add dedicated artwork for each service offering and a branded default fallback image
- wire service data to expose imageUrl values and bind the home cards directly to those assets
- remove the rotating placeholder logic so each card consistently shows the correct imagery

## Testing
- npm run build *(fails: Inlining of fonts failed. https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap returned status code: 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b41559e4832e950f3a9e5bd70796

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Service cards now display per-service images, improving visual relevance.
  - A default image is shown when a specific service image is unavailable, preventing broken or empty visuals.

- Refactor
  - Image handling in the home view is now data-driven per service, reducing reliance on positional logic and improving maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->