### PR TITLE
Remove service overlay icons from home cards

### DIFF
--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -73,16 +73,6 @@
                     (click)="openBookingModal(service)">
                     <div class="service-image" [style.background-image]="'url(' + (service.imageUrl || defaultServiceImage) + ')'">
                         <div class="service-badge" *ngIf="i === 0">Most Popular</div>
-                        <div class="service-overlay">
-                            <div class="service-icon">
-                                <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-                                    stroke-width="2">
-                                    <path d="M9 17a2 2 0 1 1-4 0 2 2 0 0 1 4 0ZM19 17a2 2 0 1 1-4 0 2 2 0 0 1 4 0Z" />
-                                    <path
-                                        d="M13 16V6a1 1 0 0 0-1-1H4a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h1m8-1a1 1 0 0 1-1 1H9m4-1V8a1 1 0 0 1 1-1h2.586a1 1 0 0 1 .707.293l2.414 2.414a1 1 0 0 1 .293.707V16a1 1 0 0 1-1 1h-1m-6-1a1 1 0 0 0 1 1h1M5 17a2 2 0 1 0 4 0m-4 0a2 2 0 1 1 4 0m6 0a2 2 0 1 0 4 0m-4 0a2 2 0 1 1 4 0" />
-                                </svg>
-                            </div>
-                        </div>
                     </div>
                     <div class="service-content">
                         <div class="service-header">

--- a/src/app/components/home/home.component.scss
+++ b/src/app/components/home/home.component.scss
@@ -357,21 +357,6 @@ $shadow-xl: 0 20px 25px -5px rgba(0, 0, 0, 0.1),
   z-index: 2;
 }
 
-.service-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  @include flex-center;
-  background: rgba(0, 0, 0, 0.1);
-}
-
-.service-icon {
-  color: white;
-  opacity: 0.9;
-}
-
 .service-content {
   padding: 32px;
 }


### PR DESCRIPTION
## Summary
- remove the overlay markup that rendered the large service icon on each home service card
- delete the unused overlay styles from the home component stylesheet

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da4aa04e20832e900def29dab71ff9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified Services cards by removing the image overlay and icon, creating a cleaner, less cluttered look.
  * Preserved the “Most Popular” badge and all other content; layout and interactions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->